### PR TITLE
mysql: require row format for replication

### DIFF
--- a/aiven_mysql_migrate/exceptions.py
+++ b/aiven_mysql_migrate/exceptions.py
@@ -43,6 +43,10 @@ class ServerIdsOverlappingException(ReplicationNotAvailableException):
     pass
 
 
+class UnsupportedBinLogFormatException(ReplicationNotAvailableException):
+    pass
+
+
 class MySQLDumpException(Exception):
     pass
 


### PR DESCRIPTION
Add extra requirement for replication method - ROW format for the binary log.
If statement/mixed format is used - it might lead to security problems/extra privileges requirement on the target DB.