### PR TITLE
mysql: fix definers removal for triggers/events in the dump

### DIFF
--- a/aiven_mysql_migrate/utils.py
+++ b/aiven_mysql_migrate/utils.py
@@ -13,6 +13,7 @@ DEFAULT_MYSQL_PORT = 3306
 
 ROUTINE_DEFINER_RE = re.compile("^CREATE DEFINER *= *(`.*?`@`.*?`) +(.*$)")
 IMPORT_DEFINER_RE = re.compile(r"^/\*!50013 DEFINER *= *`.*?`@`.*?` +SQL SECURITY DEFINER \*/$")
+EXTRA_DEFINER_RE = re.compile(r"^(/\*!(?:50003|50106) CREATE *\*/ *)(/\*!(?:50017|50117) +DEFINER *= *`.*?`@`.*?`\*/)(.*$)")
 
 GTID_START_RE = re.compile(r"^SET +@@GLOBAL.GTID_PURGED *= */\*!80000 +'\+'\*/ *'([^']*)")
 GTID_END_RE = re.compile(r"^(.*?)' *;")
@@ -160,6 +161,9 @@ class MySQLDumpProcessor:
         """Remove security definers from routines and dump meta, so that the default definer is used"""
         if IMPORT_DEFINER_RE.match(line):
             return ""
+
+        if EXTRA_DEFINER_RE.match(line):
+            return EXTRA_DEFINER_RE.sub("\\1\\3", line)
 
         return ROUTINE_DEFINER_RE.sub("CREATE \\2", line)
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -44,7 +44,18 @@ def test_mysql_dump_processor_remove_log_bin(line):
     "line_in,line_out",
     [("/*!50013 DEFINER=`admin`@`%` SQL SECURITY DEFINER */", ""),
      ("CREATE DEFINER=`admin`@`%` PROCEDURE `test`(OUT user TEXT)", "CREATE PROCEDURE `test`(OUT user TEXT)"),
-     ("CREATE DEFINER=`admin`@`%` FUNCTION `test` (user CHAR(200))", "CREATE FUNCTION `test` (user CHAR(200))")]
+     ("CREATE DEFINER=`admin`@`%` FUNCTION `test` (user CHAR(200))", "CREATE FUNCTION `test` (user CHAR(200))"),
+     (
+         "/*!50003 CREATE*/ /*!50017 DEFINER=`root`@`%`*/ /*!50003 TRIGGER `abc` BEFORE INSERT ON `xyz` "
+     "FOR EACH ROW SET @a = @a + NEW.v */;;",
+         "/*!50003 CREATE*/  /*!50003 TRIGGER `abc` BEFORE INSERT ON `xyz` FOR EACH ROW SET @a = @a + NEW.v */;;"
+     ),
+     (
+         "/*!50106 CREATE*/ /*!50117 DEFINER=`root`@`%`*/ /*!50106 EVENT `ev` ON SCHEDULE AT '2021-01-19 14:55:31' "
+     "ON COMPLETION NOT PRESERVE ENABLE DO update abc.def set b=1 */ ;;",
+         "/*!50106 CREATE*/  /*!50106 EVENT `ev` ON SCHEDULE AT '2021-01-19 14:55:31' ON COMPLETION NOT PRESERVE "
+     "ENABLE DO update abc.def set b=1 */ ;;"
+     )]
 )
 def test_mysql_dump_processor_remove_definers(line_in, line_out):
     helper = MySQLDumpProcessor()


### PR DESCRIPTION
Add regexp to remove definers from triggers/events in the dump.