### PR TITLE
cli: introduce new flags to write the validation output in json format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+## Changelog
+
+## [unreleased] - 2021-03-xx
+- Introduced two new flags `--json` and `--json-file` which can be used to verify the replication method used in json format.
+    ```
+    # json output 
+    mysql_migrate --validate-only --json --log-level error
+    {"method": "dump", "reason": "Replication method is not available due to missing TARGET_MASTER_SERVICE_URI, falling back to dump"}
+
+    # or
+
+    mysql_migrate --validate-only --json-file=/tmp/outout.json --log-level=error
+    ❯ cat /tmp/outout.json 
+    {"method": "dump", "status": "Replication method is not available due to missing TARGET_MASTER_SERVICE_URI, falling back to dump"}
+    ```

--- a/README.md
+++ b/README.md
@@ -48,24 +48,26 @@ The tool requires `mysql-client` package 8.X, which can be installed from https:
 ## Usage
 ```
 mysql_migrate --help
-usage: mysql_migrate [-h] [-d] [-f FILTER_DBS] [--validate-only]
-                     [--seconds-behind-master SECONDS_BEHIND_MASTER]
-                     [--stop-replication]
+usage: mysql_migrate [-h] [--log-level {debug,info,warning,error}] [-f FILTER_DBS] [--validate-only] [--json] [--json-file JSON_FILE]
+                     [--seconds-behind-master SECONDS_BEHIND_MASTER] [--stop-replication] [--privilege-check-user PRIVILEGE_CHECK_USER]
 
 MySQL migration tool.
 
 optional arguments:
   -h, --help            show this help message and exit
-  -d, --debug           Enable debug logging.
+  --log-level {debug,info,warning,error}
+                        Change log level
   -f FILTER_DBS, --filter-dbs FILTER_DBS
                         Comma separated list of databases to filter out during migration
   --validate-only       Run migration pre-checks only
+  --json                Print the output as json, only used in combination with --validate-style
+  --json-file JSON_FILE
+                        File-path to write the json output and skip stdout, mutually exclusive to --json and only used in combination with --validate-style
   --seconds-behind-master SECONDS_BEHIND_MASTER
                         Max replication lag in seconds to wait for, by default no wait
   --stop-replication    Stop replication, by default replication is left running
   --privilege-check-user PRIVILEGE_CHECK_USER
                         User to be used when replicating for privileges check (e.g. 'checker@%', must have REPLICATION_APPLIER grant)
-
 ```
 
 The following environment variables are used by migration script:

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -47,14 +47,14 @@ def test_mysql_dump_processor_remove_log_bin(line):
      ("CREATE DEFINER=`admin`@`%` FUNCTION `test` (user CHAR(200))", "CREATE FUNCTION `test` (user CHAR(200))"),
      (
          "/*!50003 CREATE*/ /*!50017 DEFINER=`root`@`%`*/ /*!50003 TRIGGER `abc` BEFORE INSERT ON `xyz` "
-     "FOR EACH ROW SET @a = @a + NEW.v */;;",
+         "FOR EACH ROW SET @a = @a + NEW.v */;;",
          "/*!50003 CREATE*/  /*!50003 TRIGGER `abc` BEFORE INSERT ON `xyz` FOR EACH ROW SET @a = @a + NEW.v */;;"
      ),
      (
          "/*!50106 CREATE*/ /*!50117 DEFINER=`root`@`%`*/ /*!50106 EVENT `ev` ON SCHEDULE AT '2021-01-19 14:55:31' "
-     "ON COMPLETION NOT PRESERVE ENABLE DO update abc.def set b=1 */ ;;",
+         "ON COMPLETION NOT PRESERVE ENABLE DO update abc.def set b=1 */ ;;",
          "/*!50106 CREATE*/  /*!50106 EVENT `ev` ON SCHEDULE AT '2021-01-19 14:55:31' ON COMPLETION NOT PRESERVE "
-     "ENABLE DO update abc.def set b=1 */ ;;"
+         "ENABLE DO update abc.def set b=1 */ ;;"
      )]
 )
 def test_mysql_dump_processor_remove_definers(line_in, line_out):


### PR DESCRIPTION
### Description:
    
cli: introduce new flags to write the validation output in json format
  - removed --debug flag and use --log-level to control logging
  - introduced --json flag to dump the output in json format, log level is
      set to error in this case

```
    # json output 
    mysql_migrate --validate-only --json
    {"method": "dump", "reason": "Replication method is not available due to missing TARGET_MASTER_SERVICE_URI, falling back to dump"}
```

Removed the `--json-file` after the review, didn't seem necessary after discussing the use-case:
    ~~mysql_migrate --validate-only --json-file=/tmp/outout.json --log-level=error
    ❯ cat /tmp/outout.json 
    {"method": "dump", "status": "Replication method is not available due to missing TARGET_MASTER_SERVICE_URI, falling back to dump"}~~



EDIT: current state after addressing the review.

Signed-off-by: Ankur Srivastava <ansrivas@aiven.io>