### PR TITLE
Move signals handling setup out of MySQLMigration constructor [BF-597]

### DIFF
--- a/aiven_mysql_migrate/main.py
+++ b/aiven_mysql_migrate/main.py
@@ -51,6 +51,7 @@ def main(args=None, *, app="mysql_migrate"):
         filter_dbs=args.filter_dbs,
         privilege_check_user=args.privilege_check_user,
     )
+    migration.setup_signal_handlers()
 
     LOGGER.info("MySQL migration from %s to %s", migration.source.hostname, migration.target.hostname)
 

--- a/aiven_mysql_migrate/migration.py
+++ b/aiven_mysql_migrate/migration.py
@@ -66,6 +66,7 @@ class MySQLMigration:
         if privilege_check_user:
             self.privilege_check_user = PrivilegeCheckUser.parse(privilege_check_user)
 
+    def setup_signal_handlers(self):
         signal.signal(signal.SIGINT, self._stop_migration)
         signal.signal(signal.SIGTERM, self._stop_migration)
         signal.signal(signal.SIGPIPE, self._stop_migration)


### PR DESCRIPTION
Signals handling setup will fail if migration class is created not in a main thread,
so moving it into a separate function, so can be called in case of need.