### PR TITLE
mysql: remove hardcoded SSL setup for replication

### DIFF
--- a/aiven_mysql_migrate/migration.py
+++ b/aiven_mysql_migrate/migration.py
@@ -348,7 +348,7 @@ class MySQLMigration:
         with self.target_master.cur() as cur:
             query = (
                 "CHANGE MASTER TO MASTER_HOST = %s, MASTER_PORT = %s, MASTER_USER = %s, MASTER_PASSWORD = %s, "
-                "MASTER_AUTO_POSITION = 1, MASTER_SSL = 1"
+                f"MASTER_AUTO_POSITION = 1, MASTER_SSL = {1 if self.source.ssl else 0}"
             )
             if LooseVersion(self.target.version) >= LooseVersion("8.0.19"):
                 query += ", REQUIRE_ROW_FORMAT = 1"


### PR DESCRIPTION
SSL option should depend on the source URI provided as input.