### PR TITLE
Add option to force the migration method used [MA-704]

### DIFF
--- a/requirement-dev.txt
+++ b/requirement-dev.txt
@@ -3,6 +3,6 @@ isort==5.6.4
 mypy==0.790
 pylint==2.6.0
 pylint-quotes==0.2.1
-pymysql==0.9.2
+pymysql==0.10.0
 pytest==6.1.2
 yapf==0.30.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         ],
     },
     install_requires=[
-        "pymysql==0.9.2"
+        "pymysql==0.10.0"
     ],
     license="Apache 2.0",
     name="aiven-mysql-migrate",


### PR DESCRIPTION
Adds a `--force-method` option to force the method to be used when starting the migration. This is useful for cases where we only want to try either replication or dump method and fail if the method is not successful.