### PR TITLE
Add a separate SSL pre-check when checking a connection [BF-889]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7-buster
 
 RUN apt-get update -y
 RUN apt-get install -y expect

--- a/aiven_mysql_migrate/exceptions.py
+++ b/aiven_mysql_migrate/exceptions.py
@@ -7,6 +7,10 @@ class EndpointConnectionException(MigrationPreCheckException):
     pass
 
 
+class SSLNotSupportedException(MigrationPreCheckException):
+    pass
+
+
 class WrongMigrationConfigurationException(MigrationPreCheckException):
     pass
 

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -8,6 +8,7 @@ services:
       - mysql57-src-1
       - mysql80-src-2
       - mysql80-src-3
+      - mysql80-src-4
       - mysql80-dst-1
       - mysql80-dst-2
       - mysql80-dst-3
@@ -58,6 +59,23 @@ services:
       - --log-slave-updates=ON
       - --log-bin=binlog
       - --binlog-format=ROW
+
+  mysql80-src-4:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+    command:
+      - --server-id=1
+      - --gtid-mode=ON
+      - --enforce-gtid-consistency=ON
+      - --master-info-repository=TABLE
+      - --relay-log-info-repository=TABLE
+      - --binlog-checksum=NONE
+      - --log-slave-updates=ON
+      - --log-bin=binlog
+      - --binlog-format=ROW
+      - --ssl=OFF
 
   mysql80-dst-1:
     image: mysql:8.0

--- a/requirement-dev.txt
+++ b/requirement-dev.txt
@@ -1,3 +1,4 @@
+cryptography==36.0.1
 flake8==3.8.4
 isort==5.6.4
 mypy==0.790


### PR DESCRIPTION
A separate exception can be useful when the client wants to handle a specific case of disabled/misconfigured SSL.