### PR TITLE
Fix ssl mode validation [BF-835]

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ SOURCE_SERVICE_URI="mysql://<src_admin>:<pwd>@<src_host>:<port>/?ssl-mode=REQUIR
   mysql_migrate --validate-only
 ```
 
-`ssl-mode` parameter can be one of `DISABLE` or `REQUIRED`
+`ssl-mode` parameter can be one of `DISABLED` or `REQUIRED`
 
 ## Migrate:
 ```bash

--- a/aiven_mysql_migrate/utils.py
+++ b/aiven_mysql_migrate/utils.py
@@ -55,7 +55,7 @@ class MySQLConnectionInfo:
         options = parse_qs(res.query)
         MySQLConnectionInfo._validate_options(options)
 
-        ssl = not (options and options.get("ssl-mode", ["DISABLE"]) == ["DISABLE"])
+        ssl = not (options and options.get("ssl-mode", ["DISABLED"]) in (["DISABLE"], ["DISABLED"]))
         return MySQLConnectionInfo(
             hostname=res.hostname, port=port, username=res.username, password=res.password, ssl=ssl, name=name
         )
@@ -67,11 +67,12 @@ class MySQLConnectionInfo:
 
         if options and "ssl-mode" in options:
             ssl_mode = options["ssl-mode"]
-            if ssl_mode not in (["DISABLE"], ["REQUIRE"]):
-                raise WrongMigrationConfigurationException("ssl-mode must be either 'DISABLE' or 'REQUIRE'")
+            if ssl_mode not in (["DISABLE"], ["DISABLED"], ["REQUIRED"]):
+                # don't include the legacy value in the error message
+                raise WrongMigrationConfigurationException("ssl-mode must be either 'DISABLED' or 'REQUIRED'")
 
     def to_uri(self):
-        ssl_mode = "DISABLE" if not self.ssl else "REQUIRE"
+        ssl_mode = "DISABLED" if not self.ssl else "REQUIRED"
         return f"mysql://{self.username}:{self.password}@{self.hostname}:{self.port}/?ssl-mode={ssl_mode}"
 
     def repr(self):

--- a/test/sys/test_migration.py
+++ b/test/sys/test_migration.py
@@ -29,7 +29,7 @@ def random_db_name():
 def my_wait(host, ssl=True, retries=MYSQL_WAIT_RETRIES) -> MySQLConnectionInfo:
     uri = f"mysql://root:test@{host}/"
     if not ssl:
-        uri += "?ssl-mode=DISABLE"
+        uri += "?ssl-mode=DISABLED"
     conn = MySQLConnectionInfo.from_uri(uri)
     for _ in range(retries):
         try:


### PR DESCRIPTION
Prefer the officially documented variants of ssl-mode but still accept 'DISABLE' for backwards compatibility.