### PR TITLE
Create only valid JSON output meta file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
     needs: static-checks
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-buster
+FROM python:3.8-buster
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
 RUN apt-get update -y

--- a/aiven_mysql_migrate/main.py
+++ b/aiven_mysql_migrate/main.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
 from aiven_mysql_migrate import config
 from aiven_mysql_migrate.migration import MySQLMigrateMethod, MySQLMigration
+from pathlib import Path
 
 import logging
 
@@ -53,7 +54,7 @@ def main(args=None, *, app="mysql_migrate"):
     )
     parser.add_argument(
         "--output-meta-file",
-        type=argparse.FileType("w"),
+        type=Path,
         required=False,
         default=None,
         help="Output file which includes metadata such as dump GTIDs (for replication method only) in JSON format.",

--- a/aiven_mysql_migrate/utils.py
+++ b/aiven_mysql_migrate/utils.py
@@ -2,7 +2,7 @@
 from aiven_mysql_migrate import config
 from aiven_mysql_migrate.exceptions import WrongMigrationConfigurationException
 from dataclasses import dataclass
-from typing import List, Optional, AnyStr, Dict
+from typing import AnyStr, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse
 
 import contextlib

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,3 +11,6 @@ ignore_missing_imports = True
 
 [mypy-mysql.*]
 ignore_missing_imports = True
+
+[mypy-pymysql.*]
+ignore_missing_imports = True

--- a/requirement-dev.txt
+++ b/requirement-dev.txt
@@ -1,9 +1,9 @@
 cryptography==36.0.1
 flake8==3.8.4
 isort==5.6.4
-mypy==0.790
+mypy==0.942
 pylint==2.9.0
 pylint-quotes==0.2.1
 pymysql>=0.10,<2
-pytest==6.1.2
+pytest==6.2.5
 yapf==0.30.0

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,8 +1,7 @@
-from typing import Optional, Type
-
 from aiven_mysql_migrate.exceptions import WrongMigrationConfigurationException
-from aiven_mysql_migrate.utils import MySQLDumpProcessor, MySQLConnectionInfo
+from aiven_mysql_migrate.utils import MySQLConnectionInfo, MySQLDumpProcessor
 from pytest import mark, raises
+from typing import Optional, Type
 
 
 @mark.parametrize(
@@ -127,9 +126,9 @@ def test_mysql_connection_info_to_uri(uri: str, expected: str) -> None:
     ],
 )
 def test_mysql_connection_info_from_uri_password_length(
-        password_length: int,
-        template_char: str,
-        exception_class: Optional[Type[Exception]],
+    password_length: int,
+    template_char: str,
+    exception_class: Optional[Type[Exception]],
 ) -> None:
     uri = "mysql://<user>:{}@<ip>:1234/".format(template_char * password_length)
     if exception_class is not None:


### PR DESCRIPTION
Don't create empty non valid JSON meta file in case of run other than successful replication method.
