### PR TITLE
Disallow creating child processes in migration target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-buster
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C
 RUN apt-get update -y
 RUN apt-get install -y expect
 RUN curl -L 'https://dev.mysql.com/get/mysql-apt-config_0.8.16-1_all.deb' -o mysql-apt-config_0.8.16-1_all.deb

--- a/aiven_mysql_migrate/migration.py
+++ b/aiven_mysql_migrate/migration.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import pymysql
+import resource
 import shlex
 import signal
 import subprocess
@@ -327,6 +328,9 @@ class MySQLMigration:
             stdin=subprocess.PIPE,
             stderr=subprocess.PIPE, text=True
         )
+
+        # Disallow creating child processes in migration target when this runs as non-root user.
+        resource.prlimit(self.mysql_proc.pid, resource.RLIMIT_NPROC, (0, 0))
 
         # make mypy happy
         assert self.mysqldump_proc.stdout


### PR DESCRIPTION
This prevents executing system commands on the migration target if the
initial dump contains them.

This also ensures the correct public GPG key for MySQL is imported,
which is needed to run sys tests.