### PR TITLE
Do not fail the migration when the source is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ The tool requires `mysql-client` package 8.X, which can be installed from https:
 ## Usage
 ```
 mysql_migrate --help
-usage: mysql_migrate [-h] [-d] [-f FILTER_DBS] [--validate-only]
-                     [--seconds-behind-master SECONDS_BEHIND_MASTER]
-                     [--stop-replication]
+usage: mysql_migrate [-h] [-d] [-f FILTER_DBS] [--validate-only] [--seconds-behind-master SECONDS_BEHIND_MASTER] [--stop-replication] [--privilege-check-user PRIVILEGE_CHECK_USER] [--force-method FORCE_METHOD]
+                     [--dbs-max-total-size DBS_MAX_TOTAL_SIZE] [--output-meta-file OUTPUT_META_FILE] [--allow-source-without-dbs]
 
 MySQL migration tool.
 
@@ -65,7 +64,14 @@ optional arguments:
   --stop-replication    Stop replication, by default replication is left running
   --privilege-check-user PRIVILEGE_CHECK_USER
                         User to be used when replicating for privileges check (e.g. 'checker@%', must have REPLICATION_APPLIER grant)
-
+  --force-method FORCE_METHOD
+                        Force the migration method to be used as either replication or dump.
+  --dbs-max-total-size DBS_MAX_TOTAL_SIZE
+                        Max total size of databases to be migrated, ignored by default
+  --output-meta-file OUTPUT_META_FILE
+                        Output file which includes metadata such as dump GTIDs (for replication method only) in JSON format.
+  --allow-source-without-dbs
+                        Allow migrating from a source that has no migratable databases
 ```
 
 The following environment variables are used by migration script:

--- a/aiven_mysql_migrate/migration.py
+++ b/aiven_mysql_migrate/migration.py
@@ -483,7 +483,9 @@ class MySQLMigration:
 
             time.sleep(check_interval)
 
-    def start(self, *, migration_method: MySQLMigrateMethod, seconds_behind_master: int, stop_replication: bool = False):
+    def start(
+        self, *, migration_method: MySQLMigrateMethod, seconds_behind_master: int, stop_replication: bool = False
+    ) -> None:
         LOGGER.info("Start migration of the following databases:")
         for db in self.databases:
             LOGGER.info("\t%s", db)

--- a/aiven_mysql_migrate/utils.py
+++ b/aiven_mysql_migrate/utils.py
@@ -68,7 +68,7 @@ class MySQLConnectionInfo:
             username=unquote(res.username),
             password=password,
             ssl=ssl,
-            name=name
+            name=name,
         )
 
     @staticmethod

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -44,20 +44,22 @@ def test_mysql_dump_processor_remove_log_bin(line):
 
 @mark.parametrize(
     "line_in,line_out",
-    [("/*!50013 DEFINER=`admin`@`%` SQL SECURITY DEFINER */", ""),
-     ("CREATE DEFINER=`admin`@`%` PROCEDURE `test`(OUT user TEXT)", "CREATE PROCEDURE `test`(OUT user TEXT)"),
-     ("CREATE DEFINER=`admin`@`%` FUNCTION `test` (user CHAR(200))", "CREATE FUNCTION `test` (user CHAR(200))"),
-     (
-         "/*!50003 CREATE*/ /*!50017 DEFINER=`root`@`%`*/ /*!50003 TRIGGER `abc` BEFORE INSERT ON `xyz` "
-     "FOR EACH ROW SET @a = @a + NEW.v */;;",
-         "/*!50003 CREATE*/  /*!50003 TRIGGER `abc` BEFORE INSERT ON `xyz` FOR EACH ROW SET @a = @a + NEW.v */;;"
-     ),
-     (
-         "/*!50106 CREATE*/ /*!50117 DEFINER=`root`@`%`*/ /*!50106 EVENT `ev` ON SCHEDULE AT '2021-01-19 14:55:31' "
-     "ON COMPLETION NOT PRESERVE ENABLE DO update abc.def set b=1 */ ;;",
-         "/*!50106 CREATE*/  /*!50106 EVENT `ev` ON SCHEDULE AT '2021-01-19 14:55:31' ON COMPLETION NOT PRESERVE "
-     "ENABLE DO update abc.def set b=1 */ ;;"
-     )]
+    [
+        ("/*!50013 DEFINER=`admin`@`%` SQL SECURITY DEFINER */", ""),
+        ("CREATE DEFINER=`admin`@`%` PROCEDURE `test`(OUT user TEXT)", "CREATE PROCEDURE `test`(OUT user TEXT)"),
+        ("CREATE DEFINER=`admin`@`%` FUNCTION `test` (user CHAR(200))", "CREATE FUNCTION `test` (user CHAR(200))"),
+        (
+            "/*!50003 CREATE*/ /*!50017 DEFINER=`root`@`%`*/ /*!50003 TRIGGER `abc` BEFORE INSERT ON `xyz` "
+            "FOR EACH ROW SET @a = @a + NEW.v */;;",
+            "/*!50003 CREATE*/  /*!50003 TRIGGER `abc` BEFORE INSERT ON `xyz` FOR EACH ROW SET @a = @a + NEW.v */;;"
+        ),
+        (
+            "/*!50106 CREATE*/ /*!50117 DEFINER=`root`@`%`*/ /*!50106 EVENT `ev` ON SCHEDULE AT '2021-01-19 14:55:31' "
+            "ON COMPLETION NOT PRESERVE ENABLE DO update abc.def set b=1 */ ;;",
+            "/*!50106 CREATE*/  /*!50106 EVENT `ev` ON SCHEDULE AT '2021-01-19 14:55:31' ON COMPLETION NOT PRESERVE "
+            "ENABLE DO update abc.def set b=1 */ ;;"
+        ),
+    ],
 )
 def test_mysql_dump_processor_remove_definers(line_in, line_out):
     helper = MySQLDumpProcessor()


### PR DESCRIPTION
With this change, we allow migrating from a source even if it doesn't have any migratable database, and that's possible by setting `--allow-source-without-dbs` flag, which causes the migration process to show a warning message instead of raising an exception.