### PR TITLE
migration: add --reestablish-replication option

### DIFF
--- a/aiven_mysql_migrate/exceptions.py
+++ b/aiven_mysql_migrate/exceptions.py
@@ -77,3 +77,7 @@ class MyLoaderException(Exception):
 
 class DumpToolNotFoundError(Exception):
     pass
+
+
+class IncompatibleGtidsException(MigrationPreCheckException):
+    pass

--- a/test/sys/test_migration.py
+++ b/test/sys/test_migration.py
@@ -108,6 +108,81 @@ def test_migration_replication(
 
 @mark.parametrize(
     "src,dst,dump_tool", [
+        (my_wait("mysql57-src-1"), my_wait("mysql80-dst-1"), "mysqldump"),
+        (my_wait("mysql80-src-2"), my_wait("mysql80-dst-2"), "mysqldump"),
+        (my_wait("mysql80-src-2"), my_wait("mysql80-dst-2"), "mydumper"),
+
+    ]
+)
+def test_migration_replication_with_reestablish_replication(
+        src: MySQLConnectionInfo, dst: MySQLConnectionInfo, dump_tool: str, db_name: str, tmp_path: Path
+) -> None:
+    output_meta_file = tmp_path / "meta.json"
+    with dst.cur() as cur:
+        cur.execute("STOP REPLICA FOR CHANNEL ''")
+    with src.cur() as cur:
+        cur.execute(f"CREATE DATABASE `{db_name}`")
+        cur.execute(f"USE `{db_name}`")
+        cur.execute("CREATE TABLE test (ID TEXT)")
+        cur.execute("INSERT INTO test (ID) VALUES (%s)", ["test_data"])
+        cur.execute("COMMIT")
+        cur.execute("SELECT @@GLOBAL.SERVER_UUID AS UUID")
+        server_uuid = cur.fetchone()["UUID"]
+
+    migration = MySQLMigration(
+        source_uri=src.to_uri(),
+        target_uri=dst.to_uri(),
+        target_master_uri=dst.to_uri(),
+        privilege_check_user="root@%",
+        output_meta_file=output_meta_file,
+        dump_tool=MySQLMigrateTool(dump_tool),
+    )
+    method = migration.run_checks()
+    assert method == MySQLMigrateMethod.replication
+    migration.start(migration_method=method, seconds_behind_master=0)
+    assert output_meta_file.exists()
+    with output_meta_file.open("r") as meta_file:
+        meta = json.loads(meta_file.read())
+    assert "dump_gtids" in meta
+    assert server_uuid in meta["dump_gtids"]
+
+    with dst.cur() as cur:
+        cur.execute(f"SELECT ID FROM {db_name}.test")
+        res = cur.fetchall()
+        assert len(res) == 1 and res[0]["ID"] == "test_data"
+
+    with dst.cur() as cur:
+        cur.execute("STOP REPLICA FOR CHANNEL ''")
+
+    with src.cur() as cur:
+        cur.execute(f"INSERT INTO {db_name}.test (ID) VALUES (%s)", ["repl_data"])
+        cur.execute("COMMIT")
+
+    migration = MySQLMigration(
+        source_uri=src.to_uri(),
+        target_uri=dst.to_uri(),
+        target_master_uri=dst.to_uri(),
+        privilege_check_user="root@%",
+        output_meta_file=output_meta_file,
+        dump_tool=MySQLMigrateTool(dump_tool),
+    )
+    method = migration.run_checks()
+    assert method == MySQLMigrateMethod.replication
+    migration.start(migration_method=method, seconds_behind_master=0, reestablish_replication=True)
+
+    for _ in range(5):
+        with dst.cur() as cur:
+            cur.execute(f"SELECT ID FROM {db_name}.test")
+            res = cur.fetchall()
+            if len(res) == 2 and sorted(["test_data", "repl_data"]) == sorted([item["ID"] for item in res]):
+                return
+        time.sleep(1)
+
+    raise TimeoutException()
+
+
+@mark.parametrize(
+    "src,dst,dump_tool", [
         (my_wait("mysql80-src-3"), my_wait("mysql80-dst-3"), "mysqldump"),
         (my_wait("mysql80-src-3"), my_wait("mysql80-dst-3"), "mydumper"),
         (my_wait("mysql57-src-invalid-gtid"), my_wait("mysql80-dst-1"), "mysqldump"),


### PR DESCRIPTION
Use it to retry start of the replication without repeating the dump/restore phase