### PR TITLE
mydumper: switch sync-thread-lock-mode from FTWRL to AUTO

### DIFF
--- a/aiven_mysql_migrate/dump_tools.py
+++ b/aiven_mysql_migrate/dump_tools.py
@@ -224,7 +224,7 @@ class MyDumperTool(MySQLMigrationToolBase):
             "--events",
             "--routines",
             "--chunk-filesize=1024",
-            "--sync-thread-lock-mode=FTWRL",
+            "--sync-thread-lock-mode=AUTO",
             "--no-backup-locks",
             "--skip-ddl-locks",
             "--checksum-all",

--- a/test/sys/test_migration.py
+++ b/test/sys/test_migration.py
@@ -96,12 +96,12 @@ def test_migration_replication(
         assert len(res) == 1 and res[0]["ID"] == "test_data"
 
     with src.cur() as cur:
-        cur.execute(f"INSERT INTO {db_name}.test (ID) VALUES (%s)", ["repl_data"])
+        cur.execute(f"INSERT INTO `{db_name}`.`test` (ID) VALUES (%s)", ["repl_data"])
         cur.execute("COMMIT")
 
     for _ in range(5):
         with dst.cur() as cur:
-            cur.execute(f"SELECT ID FROM {db_name}.test")
+            cur.execute(f"SELECT ID FROM `{db_name}`.`test`")
             res = cur.fetchall()
             if len(res) == 2 and sorted(["test_data", "repl_data"]) == sorted([item["ID"] for item in res]):
                 return
@@ -154,7 +154,7 @@ def test_migration_replication_with_reestablish_replication(
     assert server_uuid in meta["dump_gtids"]
 
     with dst.cur() as cur:
-        cur.execute(f"SELECT ID FROM {db_name}.test")
+        cur.execute(f"SELECT ID FROM `{db_name}`.`test`")
         res = cur.fetchall()
         assert len(res) == 1 and res[0]["ID"] == "test_data"
 
@@ -162,7 +162,7 @@ def test_migration_replication_with_reestablish_replication(
         cur.execute("STOP REPLICA FOR CHANNEL ''")
 
     with src.cur() as cur:
-        cur.execute(f"INSERT INTO {db_name}.test (ID) VALUES (%s)", ["repl_data"])
+        cur.execute(f"INSERT INTO `{db_name}`.`test` (ID) VALUES (%s)", ["repl_data"])
         cur.execute("COMMIT")
 
     migration = MySQLMigration(
@@ -179,7 +179,7 @@ def test_migration_replication_with_reestablish_replication(
 
     for _ in range(5):
         with dst.cur() as cur:
-            cur.execute(f"SELECT ID FROM {db_name}.test")
+            cur.execute(f"SELECT ID FROM `{db_name}`.`test`")
             res = cur.fetchall()
             if len(res) == 2 and sorted(["test_data", "repl_data"]) == sorted([item["ID"] for item in res]):
                 return
@@ -215,11 +215,11 @@ def test_migration_fallback(src: MySQLConnectionInfo, dst: MySQLConnectionInfo, 
     migration.start(migration_method=method, seconds_behind_master=0)
 
     with dst.cur() as cur:
-        cur.execute(f"SELECT ID FROM {db_name}.test")
+        cur.execute(f"SELECT ID FROM `{db_name}`.`test`")
         res = cur.fetchall()
         assert len(res) == 1 and res[0]["ID"] == "test_data"
 
-        cur.execute(f"call {db_name}.test_proc(@body)")
+        cur.execute(f"call `{db_name}`.`test_proc`(@body)")
         res = cur.fetchall()
         assert len(res) == 1 and res[0]["test_body"] == "test_body"
 

--- a/test/unit/test_dump_tools.py
+++ b/test/unit/test_dump_tools.py
@@ -134,7 +134,7 @@ def _build_mydumper_cmd(databases, ssl=True):
         "--events",
         "--routines",
         "--chunk-filesize=1024",
-        "--sync-thread-lock-mode=FTWRL",
+        "--sync-thread-lock-mode=AUTO",
         "--no-backup-locks",
         "--skip-ddl-locks",
         "--checksum-all",


### PR DESCRIPTION
AUTO lets mydumper detect the best available lock mode, avoiding
failures on managed database providers that lack the RELOAD privilege.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
