### PR TITLE
mydumper set sql_require_primary_key to OFF

### DIFF
--- a/aiven_mysql_migrate/dump_tools.py
+++ b/aiven_mysql_migrate/dump_tools.py
@@ -189,6 +189,8 @@ class MyDumperTool(MySQLMigrationToolBase):
             )
             if connection_info.ssl:
                 temp_cnf.write("ssl-mode=REQUIRED\n")
+            temp_cnf.write("[myloader_session_variables]\n")
+            temp_cnf.write("sql_require_primary_key=OFF\n")
 
         # Set secure permissions
         os.chmod(temp_cnf_path, 0o600)

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -15,7 +15,7 @@ services:
       - mysql80-dst-3
       - mysql84-dst-4
     volumes:
-      - .:/app
+      - .:/app:z
 
 
   mysql57-src-1:
@@ -171,3 +171,17 @@ services:
       - --binlog-checksum=NONE
       - --log-replica-updates=ON
       - --log-bin=binlog
+
+  mysql84-dst-5:
+    image: mysql:8.4
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+    command:
+      - --server-id=2
+      - --gtid-mode=ON
+      - --enforce-gtid-consistency=ON
+      - --binlog-checksum=NONE
+      - --log-replica-updates=ON
+      - --log-bin=binlog
+      - --sql-require-primary-key=ON

--- a/test/sys/test_migration.py
+++ b/test/sys/test_migration.py
@@ -355,3 +355,47 @@ def test_database_ssl_disabled(src, dst, dump_tool, db_name):
     )
     with pytest.raises(SSLNotSupportedException):
         migration.run_checks()
+
+
+@mark.parametrize(
+    "src,dst,dump_tool", [
+        (my_wait("mysql80-src-2"), my_wait("mysql84-dst-5"), "mydumper"),
+        (my_wait("mysql84-src-5"), my_wait("mysql84-dst-5"), "mydumper"),
+    ]
+)
+def test_migration_table_without_pk(
+    src: MySQLConnectionInfo, dst: MySQLConnectionInfo, dump_tool: str, db_name: str, tmp_path: Path
+) -> None:
+    output_meta_file = tmp_path / "meta.json"
+    with dst.cur() as cur:
+        cur.execute("STOP REPLICA FOR CHANNEL ''")
+    with src.cur() as cur:
+        cur.execute(f"CREATE DATABASE `{db_name}`")
+        cur.execute(f"USE `{db_name}`")
+        cur.execute("CREATE TABLE test (ID TEXT)")
+        cur.execute("INSERT INTO test (ID) VALUES (%s)", ["test_data"])
+        cur.execute("COMMIT")
+        cur.execute("SELECT @@GLOBAL.SERVER_UUID AS UUID")
+        server_uuid = cur.fetchone()["UUID"]
+
+    migration = MySQLMigration(
+        source_uri=src.to_uri(),
+        target_uri=dst.to_uri(),
+        target_master_uri=dst.to_uri(),
+        privilege_check_user="root@%",
+        output_meta_file=output_meta_file,
+        dump_tool=MySQLMigrateTool(dump_tool),
+    )
+    method = migration.run_checks()
+    assert method == MySQLMigrateMethod.replication
+    migration.start(migration_method=method, seconds_behind_master=0)
+    assert output_meta_file.exists()
+    with output_meta_file.open("r") as meta_file:
+        meta = json.loads(meta_file.read())
+    assert "dump_gtids" in meta
+    assert server_uuid in meta["dump_gtids"]
+
+    with dst.cur() as cur:
+        cur.execute(f"SELECT ID FROM `{db_name}`.`test`")
+        res = cur.fetchall()
+        assert len(res) == 1 and res[0]["ID"] == "test_data"

--- a/test/unit/test_dump_tools.py
+++ b/test/unit/test_dump_tools.py
@@ -356,7 +356,8 @@ class TestMyDumperTool:
 
         # Verify [client] section exists
         assert "client" in config.sections()
-        assert len(config.sections()) == 1, "File should contain only [client] section"
+        assert "myloader_session_variables" in config.sections()
+        assert len(config.sections()) == 2, "File should contain only [client] and [myloader_session_variables] section"
 
         # Verify exact key-value pairs
         client_section = config["client"]


### PR DESCRIPTION
When migrating the db with mydumper if the source has tables without primary keys it fails. With this fix we set to myloader session to skip the primary key check