### PR TITLE
Ignoring SQL_LOG_BIN for myloader

### DIFF
--- a/aiven_mysql_migrate/dump_tools.py
+++ b/aiven_mysql_migrate/dump_tools.py
@@ -265,6 +265,7 @@ class MyDumperTool(MySQLMigrationToolBase):
             "--drop-table",
             "--drop-database",
             "--checksum",
+            "--ignore-set=SQL_LOG_BIN",
         ]
 
         return cmd

--- a/test/unit/test_dump_tools.py
+++ b/test/unit/test_dump_tools.py
@@ -170,6 +170,7 @@ def _build_myloader_cmd():
         "--drop-table",
         "--drop-database",
         "--checksum",
+        "--ignore-set=SQL_LOG_BIN"
     ]
 
 


### PR DESCRIPTION
myloader from 1.0.0-1 when warning is present it exits with code 1 instead of 0, with --ignore-set=SQL_LOG_BIN we remove the warning to make the migration succeed.