### PR TITLE
migration_executor: propagate real failure instead of BrokenPipeError 

### DIFF
--- a/aiven_mysql_migrate/migration_executor.py
+++ b/aiven_mysql_migrate/migration_executor.py
@@ -2,17 +2,39 @@
 from aiven_mysql_migrate.enums import MySQLMigrateTool
 from aiven_mysql_migrate.exceptions import MySQLDumpException, MySQLImportException
 from aiven_mysql_migrate.utils import MySQLConnectionInfo, DumpProcessor, select_global_var
+from collections import deque
 from concurrent import futures
 from subprocess import Popen
-from typing import Callable, List, Optional
+from typing import Callable, Deque, List, Optional
 
 import concurrent
 import logging
+import re
 import resource
 import subprocess
 import sys
 
 LOGGER = logging.getLogger(__name__)
+
+STDERR_TAIL_LINES = 100
+STDERR_TAIL_MAX_BYTES = 2048
+STDERR_FALLBACK_LINES = 20
+# mydumper/myloader surface fatal worker failures via GLib's g_critical()
+# ("** (tool:pid): CRITICAL **: ...") and the MySQL client library reports
+# server errors as "ERROR NNNN". When a process exits non-zero, we prefer
+# those lines over generic log noise when building the user-visible message.
+_STDERR_SIGNAL_RE = re.compile(r"CRITICAL \*\*:|ERROR \d{3,4}")
+
+
+def _format_stderr_tail(buf: "Deque[str]") -> str:
+    if not buf:
+        return ""
+    signal_lines = [line for line in buf if _STDERR_SIGNAL_RE.search(line)]
+    selected = signal_lines if signal_lines else list(buf)[-STDERR_FALLBACK_LINES:]
+    tail = "".join(selected).strip()
+    if len(tail) > STDERR_TAIL_MAX_BYTES:
+        tail = "..." + tail[-(STDERR_TAIL_MAX_BYTES - 3):]
+    return tail
 
 
 class ProcessExecutor:
@@ -94,26 +116,55 @@ class ProcessExecutor:
             self.import_proc.stdin.flush()
             self.import_proc.stdin.close()
 
-        def _reader_stderr(proc):
+        dump_stderr_tail: Deque[str] = deque(maxlen=STDERR_TAIL_LINES)
+        import_stderr_tail: Deque[str] = deque(maxlen=STDERR_TAIL_LINES)
+
+        def _reader_stderr(proc, sink: Deque[str]):
+            # Once we've captured a critical line (CRITICAL / ERROR NNNN), stop
+            # appending non-critical lines so a subsequent flood of warnings
+            # can't evict the critical from the bounded deque.
+            critical_seen = False
             for line in proc.stderr:
                 sys.stderr.write(line)
+                if (is_critical := _STDERR_SIGNAL_RE.search(line)) or not critical_seen:
+                    sink.append(line)
+                if is_critical:
+                    critical_seen = True
 
+        reader_exc: Optional[BaseException] = None
         with futures.ThreadPoolExecutor(max_workers=3) as executor:
-            for future in concurrent.futures.as_completed([
+            submitted = [
                 executor.submit(_reader_stdout),
-                executor.submit(_reader_stderr, self.dump_proc),
-                executor.submit(_reader_stderr, self.import_proc)
-            ]):
-                future.result()
+                executor.submit(_reader_stderr, self.dump_proc, dump_stderr_tail),
+                executor.submit(_reader_stderr, self.import_proc, import_stderr_tail),
+            ]
+            for future in concurrent.futures.as_completed(submitted):
+                try:
+                    future.result()
+                except BaseException as exc:  # pylint: disable=broad-except
+                    LOGGER.debug("Reader task raised: %s", exc)
+                    if reader_exc is None:
+                        reader_exc = exc
 
         export_code = self.dump_proc.wait()
         import_code = self.import_proc.wait()
 
         if export_code != 0:
-            raise MySQLDumpException(f"Error while exporting data from the source database, exit code: {export_code}")
+            tail = _format_stderr_tail(dump_stderr_tail)
+            msg = f"Error while exporting data from the source database, exit code: {export_code}"
+            if tail:
+                msg += f". Last stderr: {tail}"
+            raise MySQLDumpException(msg)
 
         if import_code != 0:
-            raise MySQLImportException(f"Error while importing data into the target database, exit code: {import_code}")
+            tail = _format_stderr_tail(import_stderr_tail)
+            msg = f"Error while importing data into the target database, exit code: {import_code}"
+            if tail:
+                msg += f". Last stderr: {tail}"
+            raise MySQLImportException(msg)
+
+        if reader_exc is not None:
+            raise reader_exc
 
         gtid = dump_processor.get_gtid() if dump_processor else None
         return gtid

--- a/test/unit/test_migration_executor.py
+++ b/test/unit/test_migration_executor.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2026 Aiven, Helsinki, Finland. https://aiven.io/
+from aiven_mysql_migrate import migration_executor
+from aiven_mysql_migrate.enums import MySQLMigrateTool
+from aiven_mysql_migrate.exceptions import MySQLDumpException, MySQLImportException
+from aiven_mysql_migrate.migration_executor import ProcessExecutor, STDERR_TAIL_LINES, _format_stderr_tail
+from aiven_mysql_migrate.utils import MySQLConnectionInfo, MydumperDumpProcessor
+from collections import deque
+from contextlib import contextmanager
+from pytest import fixture, raises
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+
+_MYLOADER_CRITICAL = (
+    "** (myloader:1): CRITICAL **: 00:00:00.000: Thread 1 using connection 5 - "
+    "ERROR 3750: Unable to create or change a table without a primary key, when the "
+    "system variable 'sql_require_primary_key' is set.\n"
+)
+
+
+class _StubStdin:
+    """Writable stdin that can be scripted to raise BrokenPipeError."""
+
+    def __init__(self, *, raise_on_write_after: Optional[int] = None):
+        self._raise_after = raise_on_write_after
+        self._writes = 0
+        self.closed = False
+
+    def write(self, _data):
+        self._writes += 1
+        if self._raise_after is not None and self._writes > self._raise_after:
+            raise BrokenPipeError(32, "Broken pipe")
+
+    def flush(self):
+        if self._raise_after is not None and self._writes > self._raise_after:
+            raise BrokenPipeError(32, "Broken pipe")
+
+    def close(self):
+        self.closed = True
+
+
+def _stub_proc(*, stdout_lines=(), stderr_lines=(), exit_code=0, stdin=None):
+    proc = MagicMock()
+    proc.stdout = iter(list(stdout_lines))
+    proc.stderr = iter(list(stderr_lines))
+    proc.stdin = stdin if stdin is not None else _StubStdin()
+    proc.wait.return_value = exit_code
+    proc.pid = 4242
+    return proc
+
+
+@fixture(name="target_connection")
+def _target_connection():
+    conn = MagicMock(spec=MySQLConnectionInfo)
+
+    @contextmanager
+    def _cur():
+        yield MagicMock()
+
+    conn.cur.side_effect = _cur
+    return conn
+
+
+@fixture(name="dump_processor")
+def _dump_processor():
+    processor = MagicMock(spec=MydumperDumpProcessor)
+    # Each dump-stdout line flows through process_line; default pass-through.
+    processor.process_line.side_effect = lambda line: line.rstrip("\n") if line.strip() else ""
+    processor.get_gtid.return_value = None
+    return processor
+
+
+def _run_executor(dump_proc, import_proc, target_connection, dump_processor):
+    with patch.object(migration_executor, "Popen", side_effect=[dump_proc, import_proc]), \
+         patch.object(migration_executor, "select_global_var", return_value=0):
+        executor = ProcessExecutor()
+        return executor.execute_piped_commands(
+            dump_cmd=["mydumper"],
+            import_cmd=["myloader"],
+            target=target_connection,
+            dump_tool=MySQLMigrateTool.mydumper,
+            dump_processor=dump_processor,
+        )
+
+
+def test_stderr_tail_surfaced_on_import_failure(target_connection, dump_processor):
+    dump_proc = _stub_proc(stdout_lines=["schema.sql\n", "data.sql\n"], exit_code=0)
+    # Loader dies on the second write — mirrors what happens in production when
+    # a myloader worker hits ERROR 3750 and the loader process exits.
+    import_proc = _stub_proc(
+        stderr_lines=["loading schema\n", _MYLOADER_CRITICAL],
+        exit_code=1,
+        stdin=_StubStdin(raise_on_write_after=1),
+    )
+
+    with raises(MySQLImportException) as exc_info:
+        _run_executor(dump_proc, import_proc, target_connection, dump_processor)
+
+    msg = str(exc_info.value)
+    assert "exit code: 1" in msg
+    assert "ERROR 3750" in msg
+
+
+def test_stderr_tail_surfaced_on_dump_failure(target_connection, dump_processor):
+    mydumper_critical = (
+        "** (mydumper:7): CRITICAL **: 00:00:00.000: Error connecting to database: "
+        "ERROR 1045: Access denied for user 'u'@'h'\n"
+    )
+    dump_proc = _stub_proc(stderr_lines=[mydumper_critical], exit_code=2)
+    import_proc = _stub_proc(exit_code=0)
+
+    with raises(MySQLDumpException) as exc_info:
+        _run_executor(dump_proc, import_proc, target_connection, dump_processor)
+
+    msg = str(exc_info.value)
+    assert "exit code: 2" in msg
+    assert "ERROR 1045" in msg
+
+
+def test_reader_exception_is_reraised_when_exit_codes_are_clean(target_connection, dump_processor):
+    # Both subprocesses exit 0 but _reader_stdout raises (BrokenPipeError here).
+    # Without re-raise, a reader-side code bug would be silently swallowed.
+    dump_proc = _stub_proc(stdout_lines=["schema.sql\n"], exit_code=0)
+    import_proc = _stub_proc(exit_code=0, stdin=_StubStdin(raise_on_write_after=0))
+
+    with raises(BrokenPipeError):
+        _run_executor(dump_proc, import_proc, target_connection, dump_processor)
+
+
+def test_stderr_tail_bounded_preserves_signal_line(target_connection, dump_processor):
+    noise = [f"loading file-{i}.sql\n" for i in range(STDERR_TAIL_LINES * 3)]
+    # Put the critical line near the front and bury it under a warning flood
+    # that exceeds the deque's maxlen. _reader_stderr stops appending
+    # non-critical lines once a critical is seen, so the critical stays in the
+    # deque and surfaces in the message.
+    stderr_lines = [_MYLOADER_CRITICAL] + noise
+    import_proc = _stub_proc(stderr_lines=stderr_lines, exit_code=1)
+    dump_proc = _stub_proc(exit_code=0)
+
+    with raises(MySQLImportException) as exc_info:
+        _run_executor(dump_proc, import_proc, target_connection, dump_processor)
+
+    msg = str(exc_info.value)
+    assert "ERROR 3750" in msg  # critical preserved despite warning flood
+    # Message size cap holds.
+    assert len(msg) < 4096
+
+
+def test_stderr_tail_fallback_when_no_pattern_match(target_connection, dump_processor):
+    noisy_but_no_signal = [f"progress: {i}%\n" for i in range(5)]
+    import_proc = _stub_proc(stderr_lines=noisy_but_no_signal, exit_code=3)
+    dump_proc = _stub_proc(exit_code=0)
+
+    with raises(MySQLImportException) as exc_info:
+        _run_executor(dump_proc, import_proc, target_connection, dump_processor)
+
+    msg = str(exc_info.value)
+    assert "exit code: 3" in msg
+    assert "progress:" in msg
+
+
+def test_format_stderr_tail_empty_returns_empty_string():
+    assert _format_stderr_tail(deque()) == ""
+
+
+def test_format_stderr_tail_truncates_over_max_bytes():
+    long_line = "ERROR 3750: " + ("x" * 5000) + "\n"
+    tail = _format_stderr_tail(deque([long_line]))
+    assert tail.startswith("...")
+    assert len(tail) <= migration_executor.STDERR_TAIL_MAX_BYTES


### PR DESCRIPTION
ERROR 3750 because `sql_require_primary_key` is ON on the target), the streaming thread that feeds myloader's stdin raises BrokenPipeError before we ever reach `proc.wait()` — so the error surfaced to the user was the plumbing artifact, not the actual myloader error. The real stderr line went to sys.stderr (journal) and was lost.

Fix:
- Capture a bounded per-process stderr tail in addition to forwarding
  to sys.stderr.
- Drain all reader futures without letting one re-raise mid-iteration,
  so we always reach the subprocess exit-code check.
- Include the stderr tail (preferring myloader/mydumper CRITICAL /
  ERROR NNNN lines) in the MySQLDumpException / MySQLImportException
  message. The caller already serializes this into the --output-error-file
  JSON that aiven-core surfaces to users.
- Defensive fallback: if both exit codes are zero but a reader raised,
  wrap it in MySQLImportException rather than leaking the bare
  BrokenPipeError.


