### PR TITLE
Preserve transactions order

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ optional arguments:
                         Save migration error to file in JSON format.
   --allow-source-without-dbs
                         Allow migrating from a source that has no migratable databases
+  --require-preserve-commit-order In order to use replication will enforce replica_preserve_commit_order is ON or replica_parallel_workers = 1. If source is not a replica this option is ignored.
 ```
 
 The following environment variables are used by migration script:

--- a/aiven_mysql_migrate/main.py
+++ b/aiven_mysql_migrate/main.py
@@ -75,6 +75,13 @@ def main(args: Sequence[str] | None = None, *, app: str = "mysql_migrate") -> Op
         help="Allow migrating from a source that has no migratable databases"
     )
     parser.add_argument(
+        "--require-preserve-commit-order",
+        required=False,
+        default=False,
+        help="In order to use replication will enforce replica_preserve_commit_order is ON or replica_parallel_workers = 1. "
+             "If source is not a replica this option is ignored."
+    )
+    parser.add_argument(
         "--dump-tool",
         type=str,
         required=False,
@@ -122,6 +129,7 @@ def main(args: Sequence[str] | None = None, *, app: str = "mysql_migrate") -> Op
             force_method=parsed_args.force_method,
             dbs_max_total_size=dbs_max_total_size,
             reestablish_replication=parsed_args.reestablish_replication,
+            require_preserve_commit_order=parsed_args.require_preserve_commit_order,
         )
     except NothingToMigrateException:
         if not parsed_args.allow_source_without_dbs:

--- a/aiven_mysql_migrate/migration.py
+++ b/aiven_mysql_migrate/migration.py
@@ -214,6 +214,26 @@ class MySQLMigration:
             if row_format.upper() != "ROW":
                 raise UnsupportedBinLogFormatException(f"Unsupported binary log format: {row_format}, only ROW is supported")
 
+    def _check_preserve_commit_order_on(self):
+        replica_slave = "slave" if LooseVersion(self.source.version) < LooseVersion("8.0") else "replica"
+
+        with self.source.cur() as cur:
+            cur.execute(f"SHOW {replica_slave.upper()} STATUS")
+            rows = cur.fetchall()
+            if not rows:
+                LOGGER.info("Skipping preserve commit order: source is not replica")
+                return
+            # https://dev.mysql.com/doc/mysql-replication-excerpt/8.0/en/replication-options-replica.html#sysvar_replica_parallel_workers
+            # When replica_parallel_workers is equal to 1, replica_preserve_commit_order has no effect and is ignored.
+            if select_global_var(cur, f"{replica_slave}_parallel_workers") == 1:
+                LOGGER.info("Skipping preserve commit order: %s_parallel_workers=1", replica_slave)
+                return
+
+            if select_global_var(cur, f"{replica_slave}_preserve_commit_order") != 1:
+                LOGGER.info("Replication is not available: %s_preserve_commit_order=OFF", replica_slave)
+                raise ReplicationNotAvailableException(f"{replica_slave}_preserve_commit_order is OFF,"
+                                                       f" replication is not available")
+
     def _check_source_target_uuids_aligned(self):
         with self.source.cur() as cur:
             source_server_uuid = select_global_var(cur, "server_uuid")
@@ -230,6 +250,7 @@ class MySQLMigration:
         force_method: Optional[MySQLMigrateMethod] = None,
         dbs_max_total_size: Optional[float] = None,
         reestablish_replication: bool = False,
+        require_preserve_commit_order: bool = False
     ) -> MySQLMigrateMethod:
         """Raises an exception if one of the pre-checks fails, otherwise a method to be used for migration.
         If force_method is set, re-raises validation exceptions in case the chosen method is not possible."""
@@ -276,6 +297,9 @@ class MySQLMigration:
             self._check_engine_support()
             self._check_server_id_overlapping()
             self._check_bin_log_format()
+            if require_preserve_commit_order:
+                LOGGER.debug("require_preserve_commit_order is enabled")
+                self._check_preserve_commit_order_on()
         except ReplicationNotAvailableException as e:
             if not fallback_to_dump_method:
                 raise

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -14,6 +14,8 @@ services:
       - mysql80-dst-2
       - mysql80-dst-3
       - mysql84-dst-4
+      - mysql84-src-preserve-commit-order-off
+      - mysql57-src-preserve-commit-order-off
     volumes:
       - .:/app:z
 
@@ -34,6 +36,27 @@ services:
       - --log-slave-updates=ON
       - --log-bin=binlog
       - --binlog-format=ROW
+      - --slave-preserve-commit-order=OFF
+      - --slave-parallel-workers=1
+
+  mysql57-src-preserve-commit-order-off:
+    image: mysql:5.7
+    platform: linux/amd64
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+    command:
+      - --server-id=1
+      - --gtid-mode=ON
+      - --enforce-gtid-consistency=ON
+      - --master-info-repository=TABLE
+      - --relay-log-info-repository=TABLE
+      - --binlog-checksum=NONE
+      - --log-slave-updates=ON
+      - --log-bin=binlog
+      - --binlog-format=ROW
+      - --slave-preserve-commit-order=OFF
+      - --slave-parallel-workers=4
 
   mysql57-src-invalid-gtid:
     image: mysql:5.7
@@ -65,6 +88,8 @@ services:
       - --log-slave-updates=ON
       - --log-bin=binlog
       - --binlog-format=ROW
+      - --replica-preserve-commit-order=OFF
+      - --replica-parallel-workers=1
 
   mysql80-src-3:
     image: mysql:8.0
@@ -110,6 +135,23 @@ services:
       - --binlog-checksum=NONE
       - --log-replica-updates=ON
       - --log-bin=binlog
+      - --replica-preserve-commit-order=OFF
+      - --replica-parallel-workers=1
+
+  mysql84-src-preserve-commit-order-off:
+    image: mysql:8.4
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+    command:
+      - --server-id=1
+      - --gtid-mode=ON
+      - --enforce-gtid-consistency=ON
+      - --binlog-checksum=NONE
+      - --log-replica-updates=ON
+      - --log-bin=binlog
+      - --replica-preserve-commit-order=OFF
+      - --replica-parallel-workers=4
 
   mysql80-dst-1:
     image: mysql:8.0

--- a/test/sys/test_migration.py
+++ b/test/sys/test_migration.py
@@ -1,3 +1,5 @@
+from looseversion import LooseVersion
+
 from aiven_mysql_migrate.config import IGNORE_SYSTEM_DATABASES
 from aiven_mysql_migrate.enums import MySQLMigrateTool, MySQLMigrateMethod
 from aiven_mysql_migrate.exceptions import (
@@ -51,7 +53,6 @@ def my_wait(host, ssl=True, retries=MYSQL_WAIT_RETRIES) -> MySQLConnectionInfo:
         (my_wait("mysql57-src-1"), my_wait("mysql80-dst-1"), "mysqldump"),
         (my_wait("mysql80-src-2"), my_wait("mysql80-dst-2"), "mysqldump"),
         (my_wait("mysql80-src-2"), my_wait("mysql80-dst-2"), "mydumper"),
-
         (my_wait("mysql80-src-2"), my_wait("mysql84-dst-4"), "mysqldump"),
         (my_wait("mysql84-src-5"), my_wait("mysql84-dst-4"), "mysqldump"),
         (my_wait("mysql80-src-2"), my_wait("mysql84-dst-4"), "mydumper"),
@@ -222,6 +223,68 @@ def test_migration_fallback(src: MySQLConnectionInfo, dst: MySQLConnectionInfo, 
         cur.execute(f"call `{db_name}`.`test_proc`(@body)")
         res = cur.fetchall()
         assert len(res) == 1 and res[0]["test_body"] == "test_body"
+
+
+@mark.parametrize(
+    "src,dst,migration_method,replica", [
+        (
+                my_wait("mysql57-src-preserve-commit-order-off"),
+                my_wait("mysql84-dst-4"),
+                MySQLMigrateMethod.replication,
+                False),
+        (
+                my_wait("mysql57-src-preserve-commit-order-off"),
+                my_wait("mysql84-dst-4"),
+                MySQLMigrateMethod.dump,
+                True),
+        (
+                my_wait("mysql57-src-1"),
+                my_wait("mysql84-dst-4"),
+                MySQLMigrateMethod.replication,
+                True),
+        (
+                my_wait("mysql84-src-preserve-commit-order-off"),
+                my_wait("mysql84-dst-4"),
+                MySQLMigrateMethod.replication,
+                False),
+        (
+                my_wait("mysql84-src-preserve-commit-order-off"),
+                my_wait("mysql84-dst-4"),
+                MySQLMigrateMethod.dump,
+                True),
+        (
+                my_wait("mysql84-src-5"),
+                my_wait("mysql84-dst-4"),
+                MySQLMigrateMethod.replication,
+                True),
+    ]
+)
+def test_migration_preserve_order(src: MySQLConnectionInfo,
+                                  dst: MySQLConnectionInfo,
+                                  migration_method: MySQLMigrateMethod,
+                                  replica: bool,
+                                  db_name: str) -> None:
+    with src.cur() as cur:
+        cur.execute(f"CREATE DATABASE `{db_name}`")
+        cur.execute(f"USE `{db_name}`")
+        cur.execute("CREATE TABLE test (ID TEXT)")
+        cur.execute("INSERT INTO test (ID) VALUES (%s)", ["test_data"])
+        cur.execute("CREATE PROCEDURE test_proc (OUT body TEXT) BEGIN SELECT 'test_body'; END")
+        cur.execute("COMMIT")
+        if replica:
+            if src.version < LooseVersion("8.0"):
+                cur.execute("CHANGE MASTER TO MASTER_HOST='host.com'")
+            else:
+                cur.execute("CHANGE REPLICATION SOURCE TO SOURCE_HOST='host.com'")
+
+    migration = MySQLMigration(
+        source_uri=src.to_uri(),
+        target_uri=dst.to_uri(),
+        target_master_uri=dst.to_uri(),
+        dump_tool=MySQLMigrateTool.mysqldump,
+    )
+    method = migration.run_checks(require_preserve_commit_order=True)
+    assert method == migration_method
 
 
 @mark.parametrize(


### PR DESCRIPTION
Checking if replica_preserve_commit_order is ON or replica_parallel_workers is 1 to ensure that transactions order is preserved