### PR TITLE
migration: run ANALYZE TABLE on target after import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,10 @@ RUN apt-get install -y ./mydumper_1.0.0-1.bookworm_amd64.deb
 COPY . /app
 WORKDIR /app
 
+# Worktrees and CI checkouts may not contain full git history that setuptools-scm
+# needs to derive a version. Provide a fallback so the editable install succeeds.
+ARG SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AIVEN_MYSQL_MIGRATE=0.0.0+docker
+ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AIVEN_MYSQL_MIGRATE=$SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AIVEN_MYSQL_MIGRATE
+
 RUN pip install --upgrade pip
 RUN pip install -e ".[dev]"

--- a/aiven_mysql_migrate/main.py
+++ b/aiven_mysql_migrate/main.py
@@ -101,6 +101,13 @@ def main(args: Sequence[str] | None = None, *, app: str = "mysql_migrate") -> Op
         default=None,
         help="Directory path for temporary files (MyDumper only)."
     )
+    parser.add_argument(
+        "--skip-analyze-after-import",
+        action="store_true",
+        help="Skip running ANALYZE TABLE on the target after import. By default, the tool runs "
+             "ANALYZE NO_WRITE_TO_BINLOG TABLE on every migrated InnoDB table to refresh "
+             "persistent statistics.",
+    )
     parsed_args = parser.parse_args(args)
     setup_logging(debug=parsed_args.debug)
 
@@ -161,6 +168,7 @@ def main(args: Sequence[str] | None = None, *, app: str = "mysql_migrate") -> Op
         seconds_behind_master=parsed_args.seconds_behind_master,
         stop_replication=parsed_args.stop_replication,
         reestablish_replication=parsed_args.reestablish_replication,
+        skip_analyze_after_import=parsed_args.skip_analyze_after_import,
     )
 
     LOGGER.info("Migration finished.")

--- a/aiven_mysql_migrate/migration.py
+++ b/aiven_mysql_migrate/migration.py
@@ -334,6 +334,31 @@ class MySQLMigration:
 
         return self.dump_tool.execute_migration(migration_method)
 
+    def _analyze_tables(self) -> None:
+        LOGGER.info("Running ANALYZE TABLE on the target to refresh statistics")
+        if not self.databases:
+            return
+
+        with self.target.cur() as cur:
+            cur.execute(
+                "SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES "
+                f"WHERE TABLE_SCHEMA IN ({', '.join(['%s'] * len(self.databases))}) "
+                "AND TABLE_TYPE = 'BASE TABLE' AND UPPER(ENGINE) = 'INNODB'",
+                tuple(self.databases),
+            )
+            tables = [(row["TABLE_SCHEMA"], row["TABLE_NAME"]) for row in cur.fetchall()]
+
+        total = len(tables)
+        for idx, (schema, table) in enumerate(tables, start=1):
+            qualified = f"`{schema.replace('`', '``')}`.`{table.replace('`', '``')}`"
+            LOGGER.info("Analyzing table %d/%d: %s", idx, total, qualified)
+            try:
+                with self.target.cur() as cur:
+                    cur.execute(f"ANALYZE NO_WRITE_TO_BINLOG TABLE {qualified}")
+                    cur.fetchall()
+            except pymysql.Error as e:
+                LOGGER.warning("ANALYZE TABLE failed for %s: %s", qualified, e)
+
     def _set_gtid(self, gtid: str):
         LOGGER.info("GTID from the dump is `%s`", gtid)
         assert self.target_master is not None
@@ -445,13 +470,15 @@ class MySQLMigration:
         seconds_behind_master: int,
         stop_replication: bool = False,
         reestablish_replication: bool = False,
+        skip_analyze_after_import: bool = False,
     ) -> None:
         try:
             self.start_migration(
                 migration_method=migration_method,
                 seconds_behind_master=seconds_behind_master,
                 stop_replication=stop_replication,
-                reestablish_replication=reestablish_replication
+                reestablish_replication=reestablish_replication,
+                skip_analyze_after_import=skip_analyze_after_import,
             )
         except Exception as e:
             if self.output_error_file is not None:
@@ -469,6 +496,7 @@ class MySQLMigration:
         seconds_behind_master: int,
         stop_replication: bool = False,
         reestablish_replication: bool = False,
+        skip_analyze_after_import: bool = False,
     ) -> None:
         LOGGER.info("Start migration of the following databases:")
         for db in self.databases:
@@ -489,6 +517,9 @@ class MySQLMigration:
             with self.output_meta_file.open("w") as meta_file:
                 meta_file.write(json.dumps({"dump_gtids": gtid if gtid else ""}))
                 meta_file.close()
+
+        if not reestablish_replication and not skip_analyze_after_import:
+            self._analyze_tables()
 
         if migration_method == MySQLMigrateMethod.replication:
             LOGGER.info("Setting up replication to the target DB")

--- a/test/sys/test_migration.py
+++ b/test/sys/test_migration.py
@@ -422,6 +422,54 @@ def test_database_ssl_disabled(src, dst, dump_tool, db_name):
 
 @mark.parametrize(
     "src,dst,dump_tool", [
+        (my_wait("mysql80-src-2"), my_wait("mysql84-dst-4"), "mydumper"),
+        (my_wait("mysql80-src-2"), my_wait("mysql84-dst-4"), "mysqldump"),
+    ]
+)
+def test_migration_runs_analyze_after_import(
+    src: MySQLConnectionInfo, dst: MySQLConnectionInfo, dump_tool: str, db_name: str
+) -> None:
+    with dst.cur() as cur:
+        cur.execute("STOP REPLICA FOR CHANNEL ''")
+    # Create a table with a secondary index and enough rows that InnoDB will
+    # populate non-zero stats (n_rows, index_length) once ANALYZE runs.
+    with src.cur() as cur:
+        cur.execute(f"CREATE DATABASE `{db_name}`")
+        cur.execute(f"USE `{db_name}`")
+        cur.execute("CREATE TABLE test (id INT PRIMARY KEY, payload VARCHAR(64), KEY idx_payload (payload))")
+        cur.executemany(
+            "INSERT INTO test (id, payload) VALUES (%s, %s)",
+            [(i, f"row-{i}") for i in range(1, 101)],
+        )
+        cur.execute("COMMIT")
+
+    migration = MySQLMigration(
+        source_uri=src.to_uri(),
+        target_uri=dst.to_uri(),
+        target_master_uri=dst.to_uri(),
+        privilege_check_user="root@%",
+        dump_tool=MySQLMigrateTool(dump_tool),
+    )
+    method = migration.run_checks()
+    migration.start(migration_method=method, seconds_behind_master=0)
+
+    # After analyze, persistent stats should be populated. INDEX_LENGTH is the
+    # most reliable signal because it stays 0 until stats are first computed.
+    with dst.cur() as cur:
+        cur.execute(
+            "SELECT INDEX_LENGTH FROM INFORMATION_SCHEMA.TABLES "
+            "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = 'test'",
+            (db_name,),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row["INDEX_LENGTH"] and row["INDEX_LENGTH"] > 0, (
+            f"INDEX_LENGTH was {row['INDEX_LENGTH']!r}; ANALYZE TABLE should have populated it"
+        )
+
+
+@mark.parametrize(
+    "src,dst,dump_tool", [
         (my_wait("mysql80-src-2"), my_wait("mysql84-dst-5"), "mydumper"),
         (my_wait("mysql84-src-5"), my_wait("mysql84-dst-5"), "mydumper"),
     ]

--- a/test/unit/test_migration.py
+++ b/test/unit/test_migration.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 Aiven, Helsinki, Finland. https://aiven.io/
+from aiven_mysql_migrate.enums import MySQLMigrateMethod
+from aiven_mysql_migrate.migration import MySQLMigration
+from aiven_mysql_migrate.utils import MySQLConnectionInfo
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import logging
+import pymysql
+import pytest
+
+
+def _make_migration(databases, target_cursor):
+    """Construct a MySQLMigration with mocked source/target connections."""
+    migration = MySQLMigration.__new__(MySQLMigration)
+    migration._databases = databases  # pylint: disable=protected-access
+
+    target = MagicMock(spec=MySQLConnectionInfo)
+
+    @contextmanager
+    def _cur(**_kwargs):
+        yield target_cursor
+
+    target.cur.side_effect = _cur
+    migration.target = target
+    return migration
+
+
+def test_analyze_tables_runs_per_table():
+    cursor = MagicMock()
+    cursor.fetchall.side_effect = [
+        # First fetchall: list of tables on the target.
+        [
+            {"TABLE_SCHEMA": "db1", "TABLE_NAME": "t1"},
+            {"TABLE_SCHEMA": "db1", "TABLE_NAME": "t2"},
+            {"TABLE_SCHEMA": "db2", "TABLE_NAME": "t3"},
+        ],
+        # Subsequent fetchall calls drain ANALYZE TABLE result rows.
+        [], [], [],
+    ]
+    migration = _make_migration(["db1", "db2"], cursor)
+
+    migration._analyze_tables()  # pylint: disable=protected-access
+
+    executed = [call.args[0] for call in cursor.execute.call_args_list]
+    # First call enumerates tables.
+    assert executed[0].startswith("SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES")
+    assert "TABLE_TYPE = 'BASE TABLE'" in executed[0]
+    assert "UPPER(ENGINE) = 'INNODB'" in executed[0]
+    # Followed by one ANALYZE per table, in enumeration order, with NO_WRITE_TO_BINLOG.
+    assert executed[1:] == [
+        "ANALYZE NO_WRITE_TO_BINLOG TABLE `db1`.`t1`",
+        "ANALYZE NO_WRITE_TO_BINLOG TABLE `db1`.`t2`",
+        "ANALYZE NO_WRITE_TO_BINLOG TABLE `db2`.`t3`",
+    ]
+
+
+def test_analyze_tables_continues_on_per_table_error(caplog):
+    cursor = MagicMock()
+    cursor.fetchall.side_effect = [
+        [
+            {"TABLE_SCHEMA": "db1", "TABLE_NAME": "t1"},
+            {"TABLE_SCHEMA": "db1", "TABLE_NAME": "t2"},
+            {"TABLE_SCHEMA": "db1", "TABLE_NAME": "t3"},
+        ],
+        [],  # t1 ANALYZE result rows
+        [],  # t3 ANALYZE result rows (t2 raised before fetchall)
+    ]
+
+    def _execute(stmt, *_args, **_kwargs):
+        if stmt == "ANALYZE NO_WRITE_TO_BINLOG TABLE `db1`.`t2`":
+            raise pymysql.Error("boom")
+
+    cursor.execute.side_effect = _execute
+    migration = _make_migration(["db1"], cursor)
+
+    with caplog.at_level(logging.WARNING):
+        migration._analyze_tables()  # pylint: disable=protected-access
+
+    executed = [call.args[0] for call in cursor.execute.call_args_list]
+    # All three ANALYZE attempts were made despite the failure of t2.
+    assert "ANALYZE NO_WRITE_TO_BINLOG TABLE `db1`.`t1`" in executed
+    assert "ANALYZE NO_WRITE_TO_BINLOG TABLE `db1`.`t2`" in executed
+    assert "ANALYZE NO_WRITE_TO_BINLOG TABLE `db1`.`t3`" in executed
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("`db1`.`t2`" in msg and "boom" in msg for msg in messages)
+
+
+def test_analyze_tables_escapes_backticks_in_identifiers():
+    cursor = MagicMock()
+    cursor.fetchall.side_effect = [
+        [{"TABLE_SCHEMA": "weird`db", "TABLE_NAME": "tbl`name"}],
+        [],
+    ]
+    migration = _make_migration(["weird`db"], cursor)
+
+    migration._analyze_tables()  # pylint: disable=protected-access
+
+    executed = [call.args[0] for call in cursor.execute.call_args_list]
+    assert executed[1] == "ANALYZE NO_WRITE_TO_BINLOG TABLE `weird``db`.`tbl``name`"
+
+
+def test_analyze_tables_no_databases_short_circuits():
+    cursor = MagicMock()
+    migration = _make_migration([], cursor)
+
+    migration._analyze_tables()  # pylint: disable=protected-access
+
+    cursor.execute.assert_not_called()
+
+
+@pytest.mark.parametrize("skip_flag", [True, False])
+def test_start_migration_respects_skip_flag(skip_flag, monkeypatch):
+    migration = MySQLMigration.__new__(MySQLMigration)
+    migration._databases = ["db1"]  # pylint: disable=protected-access
+    migration.output_meta_file = None
+
+    calls = []
+    monkeypatch.setattr(migration, "_migrate_data", lambda *_a, **_kw: None)
+    monkeypatch.setattr(migration, "_analyze_tables", lambda: calls.append("analyze"))
+
+    migration.start_migration(
+        migration_method=MySQLMigrateMethod.dump,
+        seconds_behind_master=-1,
+        skip_analyze_after_import=skip_flag,
+    )
+    assert calls == ([] if skip_flag else ["analyze"])
+
+
+def test_start_migration_skips_analyze_when_reestablishing(monkeypatch):
+    migration = MySQLMigration.__new__(MySQLMigration)
+    migration._databases = ["db1"]  # pylint: disable=protected-access
+    migration.output_meta_file = None
+
+    calls = []
+    monkeypatch.setattr(migration, "_migrate_data", lambda *_a, **_kw: None)
+    monkeypatch.setattr(migration, "_analyze_tables", lambda: calls.append("analyze"))
+    # Replication path under reestablish skips dump and replication setup;
+    # we only care that analyze does not run.
+    monkeypatch.setattr(migration, "_set_gtid", lambda *_a, **_kw: None)
+    monkeypatch.setattr(migration, "_start_replication", lambda: None)
+    monkeypatch.setattr(migration, "_ensure_target_replica_running", lambda *_a, **_kw: None)
+
+    migration.start_migration(
+        migration_method=MySQLMigrateMethod.replication,
+        seconds_behind_master=-1,
+        reestablish_replication=True,
+    )
+    assert not calls


### PR DESCRIPTION
Persistent InnoDB stats are stale right after a mydumper-based import
(INDEX_LENGTH=0, n_rows=0) until something forces a refresh. Run
ANALYZE NO_WRITE_TO_BINLOG TABLE on every migrated InnoDB table after
the dump load completes so the optimizer has accurate statistics
immediately. Opt-out via --skip-analyze-after-import; skipped when
--reestablish-replication is set since no import happens. Per-table
errors are logged as warnings and do not abort the migration.

Dockerfile gets SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AIVEN_MYSQL_MIGRATE
so the image builds from a git worktree where setuptools-scm cannot
infer a version from the .git pointer file.

OSD-367
