### PR TITLE
_check_preserve_commit_order_on fixees

### DIFF
--- a/aiven_mysql_migrate/migration.py
+++ b/aiven_mysql_migrate/migration.py
@@ -224,8 +224,8 @@ class MySQLMigration:
                 LOGGER.info("Skipping preserve commit order: source is not replica")
                 return
             # https://dev.mysql.com/doc/mysql-replication-excerpt/8.0/en/replication-options-replica.html#sysvar_replica_parallel_workers
-            # When replica_parallel_workers is equal to 1, replica_preserve_commit_order has no effect and is ignored.
-            if select_global_var(cur, f"{replica_slave}_parallel_workers") == 1:
+            # When replica_parallel_workers is equal to 0 or 1, replica_preserve_commit_order has no effect and is ignored.
+            if select_global_var(cur, f"{replica_slave}_parallel_workers") <= 1:
                 LOGGER.info("Skipping preserve commit order: %s_parallel_workers=1", replica_slave)
                 return
 

--- a/aiven_mysql_migrate/migration.py
+++ b/aiven_mysql_migrate/migration.py
@@ -215,7 +215,7 @@ class MySQLMigration:
                 raise UnsupportedBinLogFormatException(f"Unsupported binary log format: {row_format}, only ROW is supported")
 
     def _check_preserve_commit_order_on(self):
-        replica_slave = "slave" if LooseVersion(self.source.version) < LooseVersion("8.0") else "replica"
+        replica_slave = "slave" if LooseVersion(self.source.version) < LooseVersion("8.0.22") else "replica"
 
         with self.source.cur() as cur:
             cur.execute(f"SHOW {replica_slave.upper()} STATUS")

--- a/aiven_mysql_migrate/migration.py
+++ b/aiven_mysql_migrate/migration.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
 import datetime
 
+from pymysql.constants.CR import CR_SSL_CONNECTION_ERROR
+
 from aiven_mysql_migrate import config
 from aiven_mysql_migrate.dump_tools import MySQLMigrationToolBase, get_dump_tool
 from aiven_mysql_migrate.enums import MySQLMigrateTool, MySQLMigrateMethod
@@ -181,7 +183,7 @@ class MySQLMigration:
                 with conn_info.cur():
                     pass
             except pymysql.Error as e:
-                if e.args[0] == HANDSHAKE_ERROR:
+                if e.args[0] in [HANDSHAKE_ERROR, CR_SSL_CONNECTION_ERROR]:
                     raise SSLNotSupportedException(f"SSL is required, but not supported by the {conn_info.name}") from e
                 raise EndpointConnectionException(f"Connection to {conn_info.name} failed: {e}") from e
 


### PR DESCRIPTION
SHOW REPLICA STATUS should be used from 8.0.22 and not from 8.0

ignore  replica_preserve_commit_order ON when replica_parallel_workers is 0 since parallelism is disabled