### PR TITLE
MySQL migration from AWS RDS fails

### DIFF
--- a/aiven_mysql_migrate/dump_tools.py
+++ b/aiven_mysql_migrate/dump_tools.py
@@ -3,6 +3,7 @@ import textwrap
 from abc import ABC, abstractmethod
 
 from aiven_mysql_migrate.enums import MySQLMigrateTool, MySQLMigrateMethod
+from aiven_mysql_migrate.exceptions import NoFlushTableWithReadLockException
 from aiven_mysql_migrate.migration_executor import ProcessExecutor
 from aiven_mysql_migrate.utils import MySQLConnectionInfo, MySQLDumpProcessor, MydumperDumpProcessor, DumpProcessor
 from pathlib import Path
@@ -25,6 +26,7 @@ class MySQLMigrationToolBase(ABC):
         databases: List[str],
         skip_column_stats: bool,
         *,
+        flush_table_with_read_lock_support: bool,
         dump_tool_name: MySQLMigrateTool = MySQLMigrateTool.mysqldump,
     ):
         self.source = source
@@ -33,6 +35,7 @@ class MySQLMigrationToolBase(ABC):
         self.skip_column_stats = skip_column_stats
         self.dump_tool_name = dump_tool_name
         self.process_executor = ProcessExecutor()
+        self.flush_table_with_read_lock_support = flush_table_with_read_lock_support
         self._gtid: Optional[str] = None
 
     @abstractmethod
@@ -105,6 +108,9 @@ class MySQLDumpTool(MySQLMigrationToolBase):
             "--events",
         ]
         if migration_method == MySQLMigrateMethod.replication:
+            if not self.flush_table_with_read_lock_support:
+                raise NoFlushTableWithReadLockException("The database doesn't support 'FLUSH TABLES WITH READ LOCK', "
+                                                        "replication is not supported with mysqldump use mydumper instead")
             cmd += ["--set-gtid-purged=ON"]
         else:
             cmd += ["--set-gtid-purged=OFF"]
@@ -144,8 +150,14 @@ class MyDumperTool(MySQLMigrationToolBase):
         *,
         dump_tool_name: MySQLMigrateTool = MySQLMigrateTool.mydumper,
         temp_dir: Optional[Path] = None,
+        flush_table_with_read_lock_support: bool,
     ):
-        super().__init__(source, target, databases, skip_column_stats, dump_tool_name=dump_tool_name)
+        super().__init__(source,
+                         target,
+                         databases,
+                         skip_column_stats,
+                         dump_tool_name=dump_tool_name,
+                         flush_table_with_read_lock_support=flush_table_with_read_lock_support)
         self._base_temp_dir: Optional[Path] = temp_dir
         self.temp_dir_path: Optional[Path] = None
         self._temp_dir_obj: Optional[tempfile.TemporaryDirectory] = None
@@ -226,7 +238,7 @@ class MyDumperTool(MySQLMigrationToolBase):
             "--events",
             "--routines",
             "--chunk-filesize=1024",
-            "--sync-thread-lock-mode=AUTO",
+            f"--sync-thread-lock-mode={'AUTO' if self.flush_table_with_read_lock_support else 'LOCK_ALL'}",
             "--no-backup-locks",
             "--skip-ddl-locks",
             "--checksum-all",
@@ -290,11 +302,23 @@ def get_dump_tool(
     skip_column_stats: bool,
     *,
     temp_dir: Optional[Path] = None,
+    flush_table_with_read_lock_support,
 ) -> MySQLMigrationToolBase:
     """Factory function to create dump tool instances."""
     if tool_name == MySQLMigrateTool.mysqldump:
-        return MySQLDumpTool(source, target, databases, skip_column_stats, dump_tool_name=tool_name)
+        return MySQLDumpTool(source,
+                             target,
+                             databases,
+                             skip_column_stats,
+                             dump_tool_name=tool_name,
+                             flush_table_with_read_lock_support=flush_table_with_read_lock_support)
     elif tool_name == MySQLMigrateTool.mydumper:
-        return MyDumperTool(source, target, databases, skip_column_stats, dump_tool_name=tool_name, temp_dir=temp_dir)
+        return MyDumperTool(source,
+                            target,
+                            databases,
+                            skip_column_stats,
+                            dump_tool_name=tool_name,
+                            temp_dir=temp_dir,
+                            flush_table_with_read_lock_support=flush_table_with_read_lock_support)
     else:
         raise NotImplementedError(f"Unknown dump tool: {tool_name}")

--- a/aiven_mysql_migrate/exceptions.py
+++ b/aiven_mysql_migrate/exceptions.py
@@ -31,6 +31,10 @@ class ReplicationNotAvailableException(Exception):
     pass
 
 
+class NoFlushTableWithReadLockException(ReplicationNotAvailableException):
+    pass
+
+
 class UnsupportedMySQLVersionException(ReplicationNotAvailableException):
     pass
 

--- a/aiven_mysql_migrate/migration.py
+++ b/aiven_mysql_migrate/migration.py
@@ -11,7 +11,7 @@ from aiven_mysql_migrate.exceptions import (
     MissingReplicationGrants, NothingToMigrateException, ReplicaSetupException, ReplicationNotAvailableException,
     ServerIdsOverlappingException, SSLNotSupportedException, TooManyDatabasesException,
     UnsupportedBinLogFormatException, UnsupportedMySQLEngineException, UnsupportedMySQLVersionException,
-    WrongMigrationConfigurationException
+    WrongMigrationConfigurationException, NoFlushTableWithReadLockException
 )
 from aiven_mysql_migrate.migration_error import MysqlMigrationError
 from aiven_mysql_migrate.utils import MySQLConnectionInfo, PrivilegeCheckUser, select_global_var
@@ -216,6 +216,19 @@ class MySQLMigration:
             if row_format.upper() != "ROW":
                 raise UnsupportedBinLogFormatException(f"Unsupported binary log format: {row_format}, only ROW is supported")
 
+    def _can_flush_table_with_read_lock(self) -> bool:
+        if self.dump_tool_name == MySQLMigrateTool.mysqldump and self._is_rds():
+            raise NoFlushTableWithReadLockException("The database doesn't support 'FLUSH TABLES WITH READ LOCK', "
+                                                    "replication is not supported with mysqldump use mydumper instead")
+        return True
+
+    def _is_rds(self) -> bool:
+        with self.source.cur() as cur:
+            cur.execute("SELECT count(*) AS count FROM information_schema.tables "
+                        "WHERE table_schema = 'mysql' AND table_name = 'rds_configuration'")
+            row = cur.fetchone()
+            return row["count"] == 1
+
     def _check_preserve_commit_order_on(self):
         replica_slave = "slave" if LooseVersion(self.source.version) < LooseVersion("8.0.22") else "replica"
 
@@ -299,6 +312,7 @@ class MySQLMigration:
             self._check_engine_support()
             self._check_server_id_overlapping()
             self._check_bin_log_format()
+            self._can_flush_table_with_read_lock()
             if require_preserve_commit_order:
                 LOGGER.debug("require_preserve_commit_order is enabled")
                 self._check_preserve_commit_order_on()
@@ -331,6 +345,7 @@ class MySQLMigration:
             self.target,
             self.databases,
             self.skip_column_stats,
+            flush_table_with_read_lock_support=not self._is_rds(),
             temp_dir=self.temp_dir,
         )
 

--- a/test/unit/test_dump_tools.py
+++ b/test/unit/test_dump_tools.py
@@ -1,5 +1,8 @@
 # Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+import pytest
+
 from aiven_mysql_migrate.dump_tools import (MySQLMigrationToolBase, MySQLDumpTool, MyDumperTool, get_dump_tool)
+from aiven_mysql_migrate.exceptions import NoFlushTableWithReadLockException
 from aiven_mysql_migrate.utils import MySQLConnectionInfo, MydumperDumpProcessor
 from aiven_mysql_migrate.enums import MySQLMigrateMethod, MySQLMigrateTool
 from dataclasses import dataclass
@@ -34,6 +37,7 @@ class CommandTestCase:
     skip_column_stats: bool
     expected_dump_command: List[str]
     expected_import_command: List[str]
+    flush_table_with_read_lock_support: bool = True
 
     def __str__(self):
         return self.name
@@ -116,7 +120,7 @@ def _build_mysql_cmd(ssl=True):
     return cmd
 
 
-def _build_mydumper_cmd(databases, ssl=True):
+def _build_mydumper_cmd(databases, ssl=True, flush_table_with_read_lock_support=True):
     """Build complete mydumper command with placeholder paths."""
     cmd = [
         "mydumper",
@@ -134,7 +138,7 @@ def _build_mydumper_cmd(databases, ssl=True):
         "--events",
         "--routines",
         "--chunk-filesize=1024",
-        "--sync-thread-lock-mode=AUTO",
+        f"--sync-thread-lock-mode={'AUTO' if flush_table_with_read_lock_support else 'LOCK_ALL'}",
         "--no-backup-locks",
         "--skip-ddl-locks",
         "--checksum-all",
@@ -215,6 +219,18 @@ MYSQLDUMP_COMMAND_TEST_CASES = [
         expected_import_command=_build_mysql_cmd(ssl=True),
     ),
     CommandTestCase(
+        name="mysqldump_replication_no_ftwrl",
+        tool_name=MySQLMigrateTool.mysqldump,
+        method=MySQLMigrateMethod.replication,
+        source_config=_SSL_CONFIG,
+        target_config=_SSL_CONFIG,
+        databases=["testdb1", "testdb2"],
+        skip_column_stats=False,
+        expected_dump_command=_build_mysqldump_cmd(["testdb1", "testdb2"], gtid_mode="ON", ssl=True),
+        expected_import_command=_build_mysql_cmd(ssl=True),
+        flush_table_with_read_lock_support=False,
+    ),
+    CommandTestCase(
         name="mysqldump_dump_method_no_ssl",
         tool_name=MySQLMigrateTool.mysqldump,
         method=MySQLMigrateMethod.dump,
@@ -251,6 +267,20 @@ MYDUMPER_COMMAND_TEST_CASES = [
         expected_import_command=_build_myloader_cmd(),
     ),
     CommandTestCase(
+        name="mydumper_replication_no_ftwrl",
+        tool_name=MySQLMigrateTool.mydumper,
+        method=MySQLMigrateMethod.replication,
+        source_config=_SSL_CONFIG,
+        target_config=_SSL_CONFIG,
+        databases=["testdb1", "testdb2"],
+        skip_column_stats=False,
+        expected_dump_command=_build_mydumper_cmd(["testdb1", "testdb2"],
+                                                  ssl=True,
+                                                  flush_table_with_read_lock_support=False),
+        expected_import_command=_build_myloader_cmd(),
+        flush_table_with_read_lock_support=False
+    ),
+    CommandTestCase(
         name="mydumper_dump_method_no_ssl",
         tool_name=MySQLMigrateTool.mydumper,
         method=MySQLMigrateMethod.dump,
@@ -272,7 +302,12 @@ class TestGetDumpTool:
         """Test factory returns correct tool type based on tool name."""
         databases = ["testdb"]
 
-        tool = get_dump_tool(test_case.tool_name, source_connection, target_connection, databases, skip_column_stats=False)
+        tool = get_dump_tool(test_case.tool_name,
+                             source_connection,
+                             target_connection,
+                             databases,
+                             skip_column_stats=False,
+                             flush_table_with_read_lock_support=True)
 
         assert isinstance(tool, test_case.expected_class)
         assert tool.source == source_connection
@@ -285,7 +320,12 @@ class TestGetDumpTool:
         databases = ["testdb"]
 
         with raises(NotImplementedError, match="Unknown dump tool: unknown_tool"):
-            get_dump_tool("unknown_tool", source_connection, target_connection, databases, skip_column_stats=False)
+            get_dump_tool("unknown_tool",
+                          source_connection,
+                          target_connection,
+                          databases,
+                          skip_column_stats=False,
+                          flush_table_with_read_lock_support=True)
 
 
 class TestMySQLDumpTool:
@@ -297,13 +337,21 @@ class TestMySQLDumpTool:
         source = MySQLConnectionInfo(**test_case.source_config)
         target = MySQLConnectionInfo(**test_case.target_config)
 
-        tool = MySQLDumpTool(source, target, test_case.databases, skip_column_stats=test_case.skip_column_stats)
+        tool = MySQLDumpTool(source,
+                             target,
+                             test_case.databases,
+                             skip_column_stats=test_case.skip_column_stats,
+                             flush_table_with_read_lock_support=test_case.flush_table_with_read_lock_support)
 
-        actual_dump_cmd = tool.get_dump_command(test_case.method)
-        assert actual_dump_cmd == test_case.expected_dump_command
+        if not test_case.flush_table_with_read_lock_support and test_case.method == MySQLMigrateMethod.replication:
+            with pytest.raises(NoFlushTableWithReadLockException, match="use mydumper instead"):
+                tool.get_dump_command(test_case.method)
+        else:
+            actual_dump_cmd = tool.get_dump_command(test_case.method)
+            assert actual_dump_cmd == test_case.expected_dump_command
 
-        actual_import_cmd = tool.get_import_command(test_case.method)
-        assert actual_import_cmd == test_case.expected_import_command
+            actual_import_cmd = tool.get_import_command(test_case.method)
+            assert actual_import_cmd == test_case.expected_import_command
 
 
 class TestMyDumperTool:
@@ -315,7 +363,11 @@ class TestMyDumperTool:
         source = MySQLConnectionInfo(**test_case.source_config)
         target = MySQLConnectionInfo(**test_case.target_config)
 
-        tool = MyDumperTool(source, target, test_case.databases, skip_column_stats=test_case.skip_column_stats)
+        tool = MyDumperTool(source,
+                            target,
+                            test_case.databases,
+                            skip_column_stats=test_case.skip_column_stats,
+                            flush_table_with_read_lock_support=test_case.flush_table_with_read_lock_support)
         tool.setup()
 
         try:
@@ -340,7 +392,11 @@ class TestMyDumperTool:
     ):
         """Test temporary file creation, permissions, and content."""
         source = _create_connection("source", ssl=ssl_enabled)
-        tool = MyDumperTool(source, target_connection, databases_fixture, skip_column_stats=False)
+        tool = MyDumperTool(source,
+                            target_connection,
+                            databases_fixture,
+                            skip_column_stats=False,
+                            flush_table_with_read_lock_support=True)
         tool.setup()
 
         # Verify temp files exist
@@ -383,7 +439,11 @@ class TestMyDumperTool:
 
     def test_cleanup(self, source_connection, target_connection, databases_fixture):
         """Test cleanup removes temporary files."""
-        tool = MyDumperTool(source_connection, target_connection, databases_fixture, skip_column_stats=False)
+        tool = MyDumperTool(source_connection,
+                            target_connection,
+                            databases_fixture,
+                            skip_column_stats=False,
+                            flush_table_with_read_lock_support=True)
         tool.setup()
 
         temp_dir_path = tool.temp_dir_path
@@ -431,12 +491,20 @@ class TestMyDumperTool:
 
     def test_get_gtid_returns_none_initially(self, source_connection, target_connection, databases_fixture):
         """Test get_gtid returns None before migration."""
-        tool = MyDumperTool(source_connection, target_connection, databases_fixture, skip_column_stats=False)
+        tool = MyDumperTool(source_connection,
+                            target_connection,
+                            databases_fixture,
+                            skip_column_stats=False,
+                            flush_table_with_read_lock_support=True)
         assert tool.get_gtid() is None
 
     def test_get_gtid_after_execution(self, source_connection, target_connection, databases_fixture):
         """Test get_gtid returns GTID after successful execution."""
-        tool = MyDumperTool(source_connection, target_connection, databases_fixture, skip_column_stats=False)
+        tool = MyDumperTool(source_connection,
+                            target_connection,
+                            databases_fixture,
+                            skip_column_stats=False,
+                            flush_table_with_read_lock_support=True)
         tool._gtid = _GTIDSET  # pylint: disable=protected-access
         assert tool.get_gtid() == _GTIDSET
 
@@ -451,5 +519,9 @@ class TestMySQLMigrationToolBase:
         # This should raise TypeError because MySQLMigrationToolBase is abstract
         with raises(TypeError, match="Can't instantiate abstract class"):
             MySQLMigrationToolBase(  # pylint: disable=abstract-class-instantiated
-                source_connection, target_connection, databases, skip_column_stats=False
+                source_connection,
+                target_connection,
+                databases,
+                skip_column_stats=False,
+                flush_table_with_read_lock_support=True
             )

--- a/test/unit/test_migration.py
+++ b/test/unit/test_migration.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 Aiven, Helsinki, Finland. https://aiven.io/
-from aiven_mysql_migrate.enums import MySQLMigrateMethod
+from aiven_mysql_migrate.enums import MySQLMigrateMethod, MySQLMigrateTool
+from aiven_mysql_migrate.exceptions import NoFlushTableWithReadLockException
 from aiven_mysql_migrate.migration import MySQLMigration
 from aiven_mysql_migrate.utils import MySQLConnectionInfo
 from contextlib import contextmanager
@@ -107,6 +108,29 @@ def test_analyze_tables_no_databases_short_circuits():
     migration._analyze_tables()  # pylint: disable=protected-access
 
     cursor.execute.assert_not_called()
+
+
+def test_can_flush_table_with_read_lock_raises_for_mysqldump_on_rds():
+    cursor = MagicMock()
+    # The source reports that mysql.rds_configuration exists, i.e. it is an RDS instance.
+    cursor.fetchone.return_value = {"count": 1}
+
+    migration = MySQLMigration.__new__(MySQLMigration)
+    migration.dump_tool_name = MySQLMigrateTool.mysqldump
+
+    source = MagicMock(spec=MySQLConnectionInfo)
+
+    @contextmanager
+    def _cur(**_kwargs):
+        yield cursor
+
+    source.cur.side_effect = _cur
+    migration.source = source
+
+    with pytest.raises(NoFlushTableWithReadLockException, match="use mydumper instead"):
+        migration._can_flush_table_with_read_lock()  # pylint: disable=protected-access
+
+    assert "rds_configuration" in cursor.execute.call_args.args[0]
 
 
 @pytest.mark.parametrize("skip_flag", [True, False])


### PR DESCRIPTION
AWS RDS managed databases block the 'FLUSH TABLES WITH READ LOCK' (FTWRL) command.

- mysqldump requires to have FTWRL when --set-gtid-purged=ON, there is no way to use TABLE LOCK instead, for this reason replication is not allowed in that case
- mydumper has LOCK_ALL mode, we use it in case the db doesn't support